### PR TITLE
feat: 添加Rockchip MPP (h264_rkmpp) 硬件编码支持

### DIFF
--- a/src/ustreamer/encoder.c
+++ b/src/ustreamer/encoder.c
@@ -233,8 +233,9 @@ static bool _worker_run_job(us_worker_s *wr) {
 	}else if (run->type == US_ENCODER_TYPE_FFMPEG_VIDEO) {
 		US_LOG_VERBOSE("Compressing RAW or JPEG to H.264 using FFMPEG: worker=%s, buffer=%u",
 			wr->name, job->hw->buf.index);
-		// TODO: Implement FFmpeg hardware encoding compression here
-		// For now fallback to CPU encoding
+		// Note: FFmpeg H.264 hardware encoding is handled in stream.c via us_ffmpeg_hwenc_compress()
+		// This encoder worker is primarily for MJPEG encoding. For H.264 output, refer to stream.c
+		// For now fallback to CPU MJPEG encoding for compatibility
 		us_cpu_encoder_compress(src, dest, run->quality);
 #endif	
 #ifdef WITH_MEDIACODEC

--- a/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.c
+++ b/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.c
@@ -73,6 +73,7 @@ const char* us_hwenc_type_to_string(us_hwenc_type_e type) {
 		case US_HWENC_NVENC: return "nvenc";
 		case US_HWENC_AMF: return "amf";
 		case US_HWENC_V4L2_M2M: return "v4l2m2m";
+		case US_HWENC_RKMPP: return "rkmpp";
 		case US_HWENC_MEDIACODEC: return "mediacodec";
 		case US_HWENC_VIDEOTOOLBOX: return "videotoolbox";
 		default: return "unknown";
@@ -149,6 +150,7 @@ static const char* _get_hw_device_type(us_hwenc_type_e type) {
 		case US_HWENC_VAAPI: return "vaapi";
 		case US_HWENC_NVENC: return "cuda";
 		case US_HWENC_AMF: return "d3d11va";
+		case US_HWENC_RKMPP: return NULL; // RKMPP不需要硬件设备上下文
 		case US_HWENC_VIDEOTOOLBOX: return "videotoolbox";
 		default: return NULL;
 	}
@@ -162,6 +164,7 @@ const char* us_ffmpeg_hwenc_get_codec_name(us_hwenc_type_e type) {
 		case US_HWENC_NVENC: return "h264_nvenc";
 		case US_HWENC_AMF: return "h264_amf";
 		case US_HWENC_V4L2_M2M: return "h264_v4l2m2m";
+		case US_HWENC_RKMPP: return "h264_rkmpp";
 		case US_HWENC_MEDIACODEC: return "h264_mediacodec";
 		case US_HWENC_VIDEOTOOLBOX: return "h264_videotoolbox";
 		default: return "";
@@ -280,6 +283,20 @@ us_hwenc_error_e us_ffmpeg_hwenc_create(us_ffmpeg_hwenc_s **encoder,
 		av_dict_set(&opts, "g", gop_str, 0);                  // 设置GOP大小
 		av_dict_set(&opts, "keyint_min", gop_str, 0);         // 设置最小关键帧间隔
 		// 不设置profile和level，让驱动自动选择最兼容的配置
+	} else if (type == US_HWENC_RKMPP) {
+		// RKMPP (Rockchip MPP) 硬件编码器选项
+		av_dict_set(&opts, "rc_mode", "1", 0);                // CBR模式 (0=VBR, 1=CBR, 2=CQP, 3=AVBR)
+		av_dict_set(&opts, "profile", "100", 0);              // High profile
+		av_dict_set(&opts, "level", "40", 0);                 // Level 4.0
+		av_dict_set(&opts, "coder", "1", 0);                  // CABAC熵编码器
+		// 设置关键帧间隔
+		char gop_str[16];
+		snprintf(gop_str, sizeof(gop_str), "%u", gop_size);
+		av_dict_set(&opts, "g", gop_str, 0);                  // GOP大小
+		// QP参数优化
+		av_dict_set(&opts, "qp_init", "24", 0);               // 初始QP值
+		av_dict_set(&opts, "qp_min", "16", 0);                // 最小QP值
+		av_dict_set(&opts, "qp_max", "40", 0);                // 最大QP值
 	} else if (type == US_HWENC_NVENC) {
 		av_dict_set(&opts, "preset", "fast", 0);
 		av_dict_set(&opts, "profile", "main", 0);
@@ -539,6 +556,20 @@ us_hwenc_error_e us_ffmpeg_hwenc_create_with_preset(us_ffmpeg_hwenc_s **encoder,
 		snprintf(gop_str, sizeof(gop_str), "%u", gop_size);
 		av_dict_set(&opts, "g", gop_str, 0);
 		av_dict_set(&opts, "keyint_min", gop_str, 0);
+	} else if (type == US_HWENC_RKMPP) {
+		// RKMPP (Rockchip MPP) 硬件编码器选项 - 与preset版本相同配置
+		av_dict_set(&opts, "rc_mode", "1", 0);                // CBR模式 (0=VBR, 1=CBR, 2=CQP, 3=AVBR)
+		av_dict_set(&opts, "profile", "100", 0);              // High profile
+		av_dict_set(&opts, "level", "40", 0);                 // Level 4.0
+		av_dict_set(&opts, "coder", "1", 0);                  // CABAC熵编码器
+		// 设置关键帧间隔
+		char gop_str[16];
+		snprintf(gop_str, sizeof(gop_str), "%u", gop_size);
+		av_dict_set(&opts, "g", gop_str, 0);                  // GOP大小
+		// QP参数优化
+		av_dict_set(&opts, "qp_init", "24", 0);               // 初始QP值
+		av_dict_set(&opts, "qp_min", "16", 0);                // 最小QP值
+		av_dict_set(&opts, "qp_max", "40", 0);                // 最大QP值
 	} else if (type == US_HWENC_NVENC) {
 		av_dict_set(&opts, "preset", "fast", 0);
 		av_dict_set(&opts, "profile", "main", 0);
@@ -694,12 +725,13 @@ us_hwenc_error_e us_ffmpeg_hwenc_compress(us_ffmpeg_hwenc_s *encoder,
 
 	// 确定输入和输出格式
 	enum AVPixelFormat input_format;
-	enum AVPixelFormat output_format = (encoder->type == US_HWENC_VAAPI) ? AV_PIX_FMT_NV12 : AV_PIX_FMT_YUV420P;
+	enum AVPixelFormat output_format = AV_PIX_FMT_YUV420P; // 默认格式
 	
-	// 对于VAAPI，确保使用NV12格式以匹配硬件帧上下文
+	// 对于VAAPI，使用NV12格式以匹配硬件帧上下文
 	if (encoder->type == US_HWENC_VAAPI) {
 		output_format = AV_PIX_FMT_NV12;
 	}
+	// RKMPP使用YUV420P格式更稳定
 	
 	if (src->format == V4L2_PIX_FMT_RGB24) {
 		input_format = AV_PIX_FMT_RGB24;

--- a/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.h
+++ b/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.h
@@ -15,6 +15,7 @@ typedef enum {
 	US_HWENC_AMF,        // AMD Advanced Media Framework
 	US_HWENC_NVENC,      // NVIDIA NVENC
 	US_HWENC_V4L2_M2M,   // Rockchip/AllWinner/其他SoC
+	US_HWENC_RKMPP,      // Rockchip Media Process Platform
 	US_HWENC_MEDIACODEC, // Android MediaCodec
 	US_HWENC_VIDEOTOOLBOX // Apple VideoToolbox (macOS/iOS)
 } us_hwenc_type_e;

--- a/src/ustreamer/options.c
+++ b/src/ustreamer/options.c
@@ -780,7 +780,7 @@ static void _help(FILE *fp, const us_capture_s *cap, const us_encoder_s *enc, co
 	SAY("    --h264-m2m-device </dev/path>  ─ Path to V4L2 M2M encoder device. Default: auto select.\n");
 #	ifdef WITH_FFMPEG
 	SAY("    --h264-preset <string>  ───────── FFmpeg encoder preset. Default: ultrafast.\n");
-	SAY("    --h264-hwenc <type>  ──────────── Hardware encoder type (vaapi, nvenc, amf, v4l2m2m, mediacodec, videotoolbox).\n");
+	SAY("    --h264-hwenc <type>  ──────────── Hardware encoder type (vaapi, nvenc, amf, v4l2m2m, rkmpp, mediacodec, videotoolbox).\n");
 	SAY("                                       Falls back to software encoding if hardware encoding fails. Default: disabled.\n");
 	SAY("    --h264-hwenc-fallback  ────────── Always fallback to software encoding if hardware encoding is unavailable.\n");
 	SAY("                                       Default: disabled.\n");

--- a/src/ustreamer/stream.c
+++ b/src/ustreamer/stream.c
@@ -184,13 +184,19 @@ void us_stream_loop(us_stream_s *stream) {
 				hwenc_type = US_HWENC_AMF;
 			} else if (strcasecmp(stream->h264_hwenc, "v4l2m2m") == 0) {
 				hwenc_type = US_HWENC_V4L2_M2M;
+			} else if (strcasecmp(stream->h264_hwenc, "rkmpp") == 0) {
+				hwenc_type = US_HWENC_RKMPP;
 			} else if (strcasecmp(stream->h264_hwenc, "mediacodec") == 0) {
 				hwenc_type = US_HWENC_MEDIACODEC;
 			} else if (strcasecmp(stream->h264_hwenc, "videotoolbox") == 0) {
 				hwenc_type = US_HWENC_VIDEOTOOLBOX;
+			} else {
+				US_LOG_ERROR("H264: Unknown hardware encoder type '%s', falling back to software", stream->h264_hwenc);
+				hwenc_type = US_HWENC_LIBX264;
 			}
 		}
 		
+		US_LOG_INFO("H264: Attempting to initialize %s encoder", us_hwenc_type_to_string(hwenc_type));
 		us_hwenc_error_e error = us_ffmpeg_hwenc_create(&run->ffmpeg_enc, hwenc_type, 
 			cap->width, cap->height, stream->h264_bitrate, stream->h264_gop);
 		


### PR DESCRIPTION
- 在FFmpeg硬件编码框架中新增US_HWENC_RKMPP编码器类型
- 实现h264_rkmpp编码器名称映射和rkmpp选项解析支持
- 配置RKMPP专用编码选项：CBR码率控制、High profile、CABAC熵编码
- 优化QP参数设置和GOP配置以适配Rockchip平台
- 跳过硬件设备上下文初始化（RKMPP不需要）
- 使用YUV420P像素格式确保编码稳定性
- 支持RK3588/3588S、RK3568等Rockchip MPP芯片平台
- 与现有VAAPI、NVENC等硬件编码器保持接口一致性