### PR TITLE
feat: 添加BGR24输入格式支持和完善硬件编码器格式检查

### DIFF
--- a/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.c
+++ b/src/ustreamer/encoders/ffmpeg_hwenc/ffmpeg_hwenc.c
@@ -728,6 +728,7 @@ us_hwenc_error_e us_ffmpeg_hwenc_compress(us_ffmpeg_hwenc_s *encoder,
 
 	// 检查输入帧格式
 	if (src->format != V4L2_PIX_FMT_RGB24 && 
+	    src->format != V4L2_PIX_FMT_BGR24 &&
 	    src->format != V4L2_PIX_FMT_YUYV && 
 	    src->format != V4L2_PIX_FMT_NV12 &&
 	    src->format != V4L2_PIX_FMT_NV16 &&
@@ -753,6 +754,8 @@ us_hwenc_error_e us_ffmpeg_hwenc_compress(us_ffmpeg_hwenc_s *encoder,
 	
 	if (src->format == V4L2_PIX_FMT_RGB24) {
 		input_format = AV_PIX_FMT_RGB24;
+	} else if (src->format == V4L2_PIX_FMT_BGR24) {
+		input_format = AV_PIX_FMT_BGR24;
 	} else if (src->format == V4L2_PIX_FMT_YUYV) {
 		input_format = AV_PIX_FMT_YUYV422;
 	} else if (src->format == V4L2_PIX_FMT_NV12) {
@@ -1121,7 +1124,12 @@ bool us_ffmpeg_hwenc_is_format_supported(us_hwenc_type_e encoder_type, uint32_t 
 	(void)encoder_type; // 避免编译器警告
 	switch (format) {
 		case V4L2_PIX_FMT_RGB24:
+		case V4L2_PIX_FMT_BGR24:
 		case V4L2_PIX_FMT_YUYV:
+		case V4L2_PIX_FMT_NV12:
+		case V4L2_PIX_FMT_NV16:
+		case V4L2_PIX_FMT_NV21:
+		case V4L2_PIX_FMT_NV24:
 			return true;
 		default:
 			return false;


### PR DESCRIPTION
- 新增BGR24像素格式作为硬件编码器输入支持
- 完善us_ffmpeg_hwenc_is_format_supported函数，添加对NV12/NV16/NV21/NV24格式的支持检查
- BGR24格式可通过软件转换为NV12格式供RKMPP等硬件编码器使用